### PR TITLE
Add support for named links

### DIFF
--- a/src/gemtext.rs
+++ b/src/gemtext.rs
@@ -52,6 +52,8 @@ pub fn parse_gemtext(raw_text: &str) -> Vec<GemtextToken> {
             token_data = text_tokens[0].to_owned();
         }
 
+        // TODO: The best thing to do would be to split raw_text into 3 and
+        // check for the 3rd extra data token only if mode == TokenKind::Link.
         if mode == TokenKind::Link {
             let token_copy = token_data.clone();
             let link_parts: Vec<&str> = token_copy.splitn(2, " ").collect();
@@ -104,6 +106,18 @@ mod tests {
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].kind, TokenKind::Link);
         assert_eq!(parsed[0].data, text_data);
+    }
+
+    #[test]
+    fn parser_handles_links_with_names() {
+        let raw_text = "=> www.example.com Example Link";
+        let text_data = "www.example.com";
+        let extra_data = "Example Link";
+        let parsed: Vec<GemtextToken> = parse_gemtext(raw_text);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].kind, TokenKind::Link);
+        assert_eq!(parsed[0].data, text_data);
+        assert_eq!(parsed[0].extra, extra_data);
     }
 
     #[test]

--- a/src/gemtext.rs
+++ b/src/gemtext.rs
@@ -44,7 +44,7 @@ pub fn parse_gemtext(raw_text: &str) -> Vec<GemtextToken> {
             _     => { mode = TokenKind::Text; },
         }
 
-        if mode == TokenKind::Text && text_tokens.len() > 1{
+        if mode == TokenKind::Text && text_tokens.len() > 1 {
             token_data = format!("{} {}", text_tokens[0], text_tokens[1]);
         } else if mode != TokenKind::Text && text_tokens.len() > 1 {
             token_data = text_tokens[1].to_owned();
@@ -52,11 +52,32 @@ pub fn parse_gemtext(raw_text: &str) -> Vec<GemtextToken> {
             token_data = text_tokens[0].to_owned();
         }
 
-        gemtext_token_chain.push(GemtextToken {
-            kind: mode,
-            data: token_data,
-            extra: "".to_owned(),
-        });
+        if mode == TokenKind::Link {
+            let token_copy = token_data.clone();
+            let link_parts: Vec<&str> = token_copy.splitn(2, " ").collect();
+
+            // If the link has user friendly name store it in extra, otherwise
+            // keep it empty.
+            if link_parts.len() > 1 {
+                gemtext_token_chain.push(GemtextToken {
+                    kind: mode,
+                    data: link_parts[0].to_owned(),
+                    extra: link_parts[1].to_owned(),
+                });
+            } else {
+                gemtext_token_chain.push(GemtextToken {
+                    kind: mode,
+                    data: link_parts[0].to_owned(),
+                    extra: "".to_owned(),
+                });
+            }
+        } else {
+            gemtext_token_chain.push(GemtextToken {
+                kind: mode,
+                data: token_data,
+                extra: "".to_owned(),
+            });
+        }
     }
     
     gemtext_token_chain

--- a/src/gemtext.rs
+++ b/src/gemtext.rs
@@ -13,6 +13,8 @@ pub enum TokenKind {
 pub struct GemtextToken {
     pub kind: TokenKind,
     pub data: String,
+    pub extra: String,  // Right now this will be empty except when links are
+                        // named, when it will hold the user friendly name.
 }
 
 impl std::fmt::Display for GemtextToken {
@@ -53,6 +55,7 @@ pub fn parse_gemtext(raw_text: &str) -> Vec<GemtextToken> {
         gemtext_token_chain.push(GemtextToken {
             kind: mode,
             data: token_data,
+            extra: "".to_owned(),
         });
     }
     


### PR DESCRIPTION
Gemini supports links with a user friendly name separated by whitespace from the link. This PR adds support for these names and stores them in a new `extra` field in `GemtextToken`.